### PR TITLE
fix(discord-bot): harden /speak interaction diagnostics and ack handling

### DIFF
--- a/src/bot_runtime/container.py
+++ b/src/bot_runtime/container.py
@@ -2,6 +2,8 @@
 
 import importlib.util
 import logging
+import os
+import uuid
 
 import discord
 from discord import app_commands
@@ -45,6 +47,7 @@ class Container:
 
     def __init__(self, config: Config):
         self.config = config
+        self.process_marker = f"pid={os.getpid()} run={uuid.uuid4().hex[:8]}"
         self._commands_synced = False
         intents = discord.Intents.default()
         intents.voice_states = True
@@ -128,6 +131,7 @@ class Container:
             leave_use_case=self.leave_use_case,
             voice_runtime_availability=self.voice_runtime_availability,
             tts_catalog=self.tts_catalog,
+            runtime_context_provider=self._runtime_context,
         )
 
         self._log_voice_runtime_status()
@@ -181,8 +185,21 @@ class Container:
 
     def _register_events(self):
         @self.discord_client.event
+        async def on_connect():
+            logger.info(
+                "[GATEWAY] Connected to Discord gateway | process=%s | session_id=%s",
+                self.process_marker,
+                self._gateway_session_id(),
+            )
+
+        @self.discord_client.event
         async def on_ready():
-            logger.info("Discord bot ready as %s", self.discord_client.user)
+            logger.info(
+                "Discord bot ready as %s | process=%s | session_id=%s",
+                self.discord_client.user,
+                self.process_marker,
+                self._gateway_session_id(),
+            )
             logger.info("Connected to %s guild(s)", len(self.discord_client.guilds))
             for guild in self.discord_client.guilds:
                 logger.info("Guild connected: %s (ID: %s)", guild.name, guild.id)
@@ -190,8 +207,36 @@ class Container:
             await self._start_queue_worker_once()
 
         @self.discord_client.event
+        async def on_resumed():
+            logger.info(
+                "[GATEWAY] Discord gateway session resumed | process=%s | session_id=%s",
+                self.process_marker,
+                self._gateway_session_id(),
+            )
+
+        @self.discord_client.event
+        async def on_disconnect():
+            logger.warning(
+                "[GATEWAY] Disconnected from Discord gateway | process=%s | session_id=%s | client_ready=%s",
+                self.process_marker,
+                self._gateway_session_id(),
+                self.discord_client.is_ready(),
+            )
+
+        @self.discord_client.event
         async def on_voice_state_update(member, before, after):
             self.voice_channel_repository.update_member_cache(member.id, after.channel)
+
+    def _gateway_session_id(self) -> str:
+        ws = getattr(self.discord_client, "ws", None)
+        session_id = getattr(ws, "session_id", None)
+        return session_id or "unknown"
+
+    def _runtime_context(self) -> dict[str, str]:
+        return {
+            "process": self.process_marker,
+            "session_id": self._gateway_session_id(),
+        }
 
     async def _sync_commands_once(self) -> None:
         """Sync slash commands only once per process to avoid reconnect churn."""

--- a/src/presentation/discord_commands.py
+++ b/src/presentation/discord_commands.py
@@ -1,6 +1,9 @@
 """Discord bot commands."""
 
+import inspect
 import logging
+from datetime import datetime, timedelta
+from typing import Callable
 
 import discord
 from discord import app_commands
@@ -45,6 +48,7 @@ class DiscordCommands:
         leave_use_case: LeaveVoiceChannelUseCase,
         voice_runtime_availability: VoiceRuntimeAvailability,
         tts_catalog: TTSCatalog,
+        runtime_context_provider: Callable[[], dict[str, str]] | None = None,
     ):
         self._tree = tree
         self._speak_use_case = speak_use_case
@@ -53,6 +57,7 @@ class DiscordCommands:
         self._leave_use_case = leave_use_case
         self._voice_runtime_availability = voice_runtime_availability
         self._tts_catalog = tts_catalog
+        self._runtime_context_provider = runtime_context_provider
         self._join_presenter = DiscordJoinPresenter()
         self._leave_presenter = DiscordLeavePresenter()
         self._speak_presenter = DiscordSpeakPresenter()
@@ -150,14 +155,29 @@ class DiscordCommands:
         await interaction.response.send_message(self._leave_presenter.build_message(result), ephemeral=True)
 
     async def _handle_speak(self, interaction: discord.Interaction, text: str, voz: str | None = None):
+        runtime_context = self._runtime_log_context()
         logger.info(
-            "[SPEAK] Command from user %s (%s) in guild %s",
+            "[SPEAK] Received interaction_id=%s from user %s (%s) in guild %s | process=%s | session_id=%s",
+            interaction.id,
             interaction.user.id,
             interaction.user.name,
             interaction.guild.id if interaction.guild else "None",
+            runtime_context["process"],
+            runtime_context["session_id"],
         )
+
         if not await self._defer_speak_interaction(interaction):
             return
+
+        logger.info(
+            "[SPEAK] Deferred interaction_id=%s from user %s (%s) in guild %s | process=%s | session_id=%s",
+            interaction.id,
+            interaction.user.id,
+            interaction.user.name,
+            interaction.guild.id if interaction.guild else "None",
+            runtime_context["process"],
+            runtime_context["session_id"],
+        )
 
         if not self._get_voice_runtime_status().is_available:
             self._log_voice_runtime_unavailable("speak")
@@ -201,12 +221,86 @@ class DiscordCommands:
                 logger.debug("[SPEAK] Could not send error message: %s", send_error)
 
     async def _defer_speak_interaction(self, interaction: discord.Interaction) -> bool:
+        runtime_context = self._runtime_log_context()
+        response_done = await self._interaction_response_done(interaction)
+        if response_done:
+            logger.warning(
+                "[SPEAK] Interaction already acknowledged before defer attempt | guild=%s | user=%s | process=%s | session_id=%s",
+                interaction.guild.id if interaction.guild else "None",
+                interaction.user.id if interaction.user else "None",
+                runtime_context["process"],
+                runtime_context["session_id"],
+            )
+            return False
+
         try:
             await interaction.response.defer(ephemeral=True, thinking=True)
             return True
         except discord.NotFound as exc:
-            logger.warning("[SPEAK] Interaction expired before initial defer: %s", exc)
+            created_at = getattr(interaction, "created_at", None)
+            interaction_age_ms = None
+            if isinstance(created_at, datetime):
+                interaction_age = discord.utils.utcnow() - created_at
+                interaction_age_ms = max(int(interaction_age / timedelta(milliseconds=1)), 0)
+
+            logger.warning(
+                "[SPEAK] Interaction expired before initial defer: %s | age_ms=%s | response_done=%s | guild=%s | user=%s | process=%s | session_id=%s",
+                exc,
+                interaction_age_ms if interaction_age_ms is not None else "unknown",
+                interaction.response.is_done() if hasattr(interaction.response, "is_done") else "unknown",
+                interaction.guild.id if interaction.guild else "None",
+                interaction.user.id if interaction.user else "None",
+                runtime_context["process"],
+                runtime_context["session_id"],
+            )
             return False
+        except discord.HTTPException as exc:
+            if getattr(exc, "code", None) == 40060:
+                created_at = getattr(interaction, "created_at", None)
+                interaction_age_ms = None
+                if isinstance(created_at, datetime):
+                    interaction_age = discord.utils.utcnow() - created_at
+                    interaction_age_ms = max(int(interaction_age / timedelta(milliseconds=1)), 0)
+
+                logger.warning(
+                    "[SPEAK] Interaction already acknowledged during defer attempt: %s | age_ms=%s | response_done=%s | guild=%s | user=%s | process=%s | session_id=%s",
+                    exc,
+                    interaction_age_ms if interaction_age_ms is not None else "unknown",
+                    await self._interaction_response_done(interaction),
+                    interaction.guild.id if interaction.guild else "None",
+                    interaction.user.id if interaction.user else "None",
+                    runtime_context["process"],
+                    runtime_context["session_id"],
+                )
+                return False
+
+            raise
+
+    async def _interaction_response_done(self, interaction: discord.Interaction) -> bool:
+        response = getattr(interaction, "response", None)
+        if response is None or not hasattr(response, "is_done"):
+            return False
+
+        is_done_result = response.is_done()
+        if inspect.isawaitable(is_done_result):
+            is_done_result = await is_done_result
+        if isinstance(is_done_result, bool):
+            return is_done_result
+        return False
+
+    def _runtime_log_context(self) -> dict[str, str]:
+        if self._runtime_context_provider is None:
+            return {"process": "unknown", "session_id": "unknown"}
+
+        try:
+            context = self._runtime_context_provider() or {}
+        except Exception:
+            return {"process": "unknown", "session_id": "unknown"}
+
+        return {
+            "process": str(context.get("process", "unknown")),
+            "session_id": str(context.get("session_id", "unknown")),
+        }
 
     def _build_speak_message(self, result) -> str:
         return self._speak_presenter.build_message(result)

--- a/tests/unit/presentation/test_discord_commands.py
+++ b/tests/unit/presentation/test_discord_commands.py
@@ -193,6 +193,31 @@ class TestDiscordCommands:
         interaction.response.defer.assert_awaited_once()
         commands_instance._speak_use_case.execute.assert_not_awaited()
         interaction.edit_original_response.assert_not_called()
+
+    @pytest.mark.asyncio
+    async def test_handle_speak_ignores_already_acknowledged_interaction_before_defer(self, commands_instance):
+        commands_instance._speak_use_case.execute = AsyncMock()
+        interaction = Mock()
+        interaction.user = Mock()
+        interaction.user.id = 11111
+        interaction.user.name = "User"
+        interaction.guild = Mock()
+        interaction.guild.id = 67890
+        interaction.response = Mock()
+        interaction.response.is_done = Mock(return_value=False)
+        interaction.response.defer = AsyncMock(
+            side_effect=discord.HTTPException(
+                Mock(),
+                {"code": 40060, "message": "Interaction has already been acknowledged."},
+            )
+        )
+        interaction.edit_original_response = AsyncMock()
+
+        await commands_instance._handle_speak(interaction, "Test")
+
+        interaction.response.defer.assert_awaited_once()
+        commands_instance._speak_use_case.execute.assert_not_awaited()
+        interaction.edit_original_response.assert_not_called()
     
     @pytest.mark.asyncio
     async def test_handle_speak_failure(self, commands_instance):


### PR DESCRIPTION
- log received and deferred interaction phases for /speak
- add process/session context to gateway and command logs
- handle expired/already-acknowledged interaction cases safely
- cover the new interaction ack path with tests

## Summary

<!-- What changed and why? Prefer 3-6 lines with product or technical context. -->

## Change Type

- [ ] Bug fix
- [ ] Feature
- [ ] Refactor
- [ ] Documentation
- [ ] Test or validation improvement
- [ ] Performance or reliability

## Architecture Impact

<!-- Explain only what matters for review. -->

- Affected areas:
  - [ ] Discord bot
  - [ ] Windows hotkey desktop app
  - [ ] Shared layers in `src/`
- Runtime summary:
  - [ ] Bot only
  - [ ] Desktop only
  - [ ] Both runtimes
- Architecture notes:
  - Did this change move, extract, or duplicate logic?
  - Were any clean architecture boundaries touched?
  - If desktop-specific code changed, why can it not live in shared code?
- Contracts:
  - [ ] No reusable contract changed
  - [ ] Existing contract changed
  - [ ] New explicit contract introduced
  - Contract notes:
    - `...`
- Compatibility:
  - [ ] No temporary compatibility path
  - [ ] Temporary compatibility path introduced
  - [ ] Temporary compatibility path removed or narrowed
  - Cleanup trigger or intended steady state:
    - `...`

## Validation

<!-- Replace with the concrete checks you actually ran. -->

- Automated checks:
  - `...`
- Manual validation:
  - `...`
- Startup or runtime verification:
  - [ ] Discord bot path validated
  - [ ] Windows desktop app path validated
  - [ ] Not applicable, with reason explained below
- Validation gaps or unrun checks:
  - `...`

## Risks and Review Focus

<!-- Call out the main risks, tradeoffs, or places where reviewers should look closely. -->

- Risk areas:
  - `...`
- Reviewer focus:
  - `...`

## Documentation Impact

- [ ] No documentation update needed
- [ ] Documentation updated in `docs/`
- [ ] Workflow or guidance updated in `.specify/`
- [ ] Derivative instruction files updated (`AGENTS.md`, `.github/`, skills)

<!-- If instructions or governance changed, keep `.specify/` as the source of truth.
Update tool-specific instruction files only to point back to the canonical docs. -->

## Screenshots or Recordings

<!-- Add screenshots, GIFs, or short notes for UI changes when helpful. -->

## Related Issues

<!-- Example: Closes #123 -->

## Notes

<!-- Anything reviewers should know before merging. -->
